### PR TITLE
Add doclinks for apl symbols

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install git+https://github.com/fastai/nbprocess.git
+          pip install nbdev-apl
       - name: Build website
         run: nbprocess_docs
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Add doclinks for apl symbols @jph00 

I verified both locally and in gh-pages branch of my fork that links are being created.