### PR TITLE
Test hidden metadata effects

### DIFF
--- a/APL.ipynb
+++ b/APL.ipynb
@@ -52,7 +52,7 @@
    "execution_count": 1,
    "id": "39913487",
    "metadata": {
-    "hidden": true
+    "hidden": false
    },
    "outputs": [
     {
@@ -75,9 +75,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "8981783e",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
 With these changes those 2 modified code cells (metadata changes only) show up.  The metadata I deleted is inserted by the ToC extension. I tested locally to verify this addresses it.
 
This metadata is from the toc extension and have a theory that it is getting picked up by Quarto.  

We could strip this metadata out always but then ToC will assume everything is expanded and won’t retain collapse memory (so not a good option imo).  ToC uses that to know what to have collapsed and not upon first open I believe. 

Ideally we could strip out this metadata before passing it to Quarto, but not in the notebook itself. Happy to do a PR if you can point me in the right direction for where that kind of stuff is implemented in nbprocess.