### PR TITLE
Fix magnitude of `0.6j0.8`

### DIFF
--- a/01_APL.ipynb
+++ b/01_APL.ipynb
@@ -1236,7 +1236,7 @@
    "id": "82f87398",
    "metadata": {},
    "source": [
-    "`0.6j0.8` represents a vector in the same direction as `3j4`, but with a magnitude of 5, since it's `3j4÷5`."
+    "`0.6j0.8` represents a vector in the same direction as `3j4`, but with a magnitude of 1, since it's `3j4÷5`."
    ]
   },
   {


### PR DESCRIPTION
Tiny fix: `0.6j0.8` has a magnitude of 1 rather than 5.